### PR TITLE
Fix Win32 build, value check warning

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -156,6 +156,10 @@ dummy := $(call unnest-vars,.., \
 all-obj-y += $(common-obj-y)
 all-obj-$(CONFIG_SOFTMMU) += $(block-obj-y)
 
+ifdef CONFIG_WIN32
+LIBS+=-lgdi32
+endif
+
 ifndef CONFIG_HAIKU
 LIBS+=-lm
 endif

--- a/hw/vigs/vigs_gl_backend_wgl.c
+++ b/hw/vigs/vigs_gl_backend_wgl.c
@@ -34,6 +34,8 @@
 #include <GL/gl.h>
 #include <GL/wglext.h>
 
+HWND vigs_window = 0;
+
 #define VIGS_WGL_WIN_CLASS "VIGSWinClass"
 
 #define VIGS_WGL_GET_PROC(proc_type, proc_name, label) \
@@ -709,7 +711,7 @@ struct vigs_backend *vigs_gl_backend_create(void *display)
     }
 
     VIGS_LOG_DEBUG("created");
-
+	
     return &gl_backend_wgl->base.base;
 
 fail:

--- a/hw/virtio/virtio-rng.c
+++ b/hw/virtio/virtio-rng.c
@@ -140,7 +140,7 @@ static void virtio_rng_device_realize(DeviceState *dev, Error **errp)
     VirtIORNG *vrng = VIRTIO_RNG(dev);
     Error *local_err = NULL;
 
-    if (!vrng->conf.period_ms > 0) {
+    if (vrng->conf.period_ms <= 0) {
         error_set(errp, QERR_INVALID_PARAMETER_VALUE, "period",
                   "a positive number");
         return;

--- a/hw/yagl/yagl_device.c
+++ b/hw/yagl/yagl_device.c
@@ -58,7 +58,11 @@
 
 struct work_queue;
 
+#ifdef _WIN32
+extern void *vigs_display;
+#else
 extern Display *vigs_display;
+#endif
 extern struct work_queue *vigs_render_queue;
 extern struct winsys_interface *vigs_wsi;
 

--- a/ui/sdl.c
+++ b/ui/sdl.c
@@ -37,7 +37,11 @@
 #include "x_keymap.h"
 #include "sdl_zoom.h"
 
+#ifdef _WIN32
+extern HWND vigs_window;
+#else
 extern Window vigs_window;
+#endif
 extern uint32_t vigs_window_width;
 extern uint32_t vigs_window_height;
 
@@ -971,7 +975,11 @@ void sdl_display_init(DisplayState *ds, int full_screen, int no_frame)
             fprintf(stderr, "Cannot get SDL WM info\n");
             exit(1);
         }
+#ifdef _WIN32
+        vigs_window = wm_info.window;
+#else
         vigs_window = wm_info.info.x11.window;
+#endif
     }
 }
 #endif


### PR DESCRIPTION
Allow Win32 build to succeed.
Fix error-warning on value check, related to bad operator
placement (already fixed upstream).

Signed-off-by: Tarnyko <tarnyko@tarnyko.net>